### PR TITLE
list slicing is corrected + transition to Python 3 is made easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+__pycache__

--- a/redis_wrap/__init__.py
+++ b/redis_wrap/__init__.py
@@ -57,11 +57,11 @@ Example of other redis connection::
 """
 import redis
 
-from redis_systems import *
-from redis_list import ListFu
-from redis_hash import HashFu
-from redis_set import SetFu
-from redis_bitset import BitsetFu
+from .redis_systems import *
+from .redis_list import ListFu
+from .redis_hash import HashFu
+from .redis_set import SetFu
+from .redis_bitset import BitsetFu
 
 #--- Decorators ----------------------------------------------
 def get_list(name, system='default'):

--- a/redis_wrap/redis_bitset.py
+++ b/redis_wrap/redis_bitset.py
@@ -1,5 +1,4 @@
-
-from redis_systems import *
+from .redis_systems import *
 
 class BitsetFu (redis_obj):
 

--- a/redis_wrap/redis_hash.py
+++ b/redis_wrap/redis_hash.py
@@ -1,4 +1,4 @@
-from redis_systems import *
+from .redis_systems import *
 
 class HashFu (redis_obj):
 
@@ -67,4 +67,3 @@ class HashFu (redis_obj):
 
     def __contains__(self, key):
         return self.conn.hexists(self.name, key)
-

--- a/redis_wrap/redis_list.py
+++ b/redis_wrap/redis_list.py
@@ -1,5 +1,4 @@
-
-from redis_systems import *
+from .redis_systems import *
 
 class ListFu (redis_obj):
 
@@ -26,7 +25,7 @@ class ListFu (redis_obj):
 
     def __getitem__(self, key):
         if isinstance(key, slice):
-            return self.conn.lrange(self.name, key.start, key.stop)
+            return self.conn.lrange(self.name, key.start, key.stop-1)
 
         val = self.conn.lindex(self.name, key)
         if not val:
@@ -48,4 +47,3 @@ class ListFu (redis_obj):
             for item in items:
                 yield item
             i += 30
-

--- a/redis_wrap/redis_set.py
+++ b/redis_wrap/redis_set.py
@@ -1,5 +1,4 @@
-
-from redis_systems import *
+from .redis_systems import *
 
 class SetFu (redis_obj):
 
@@ -82,4 +81,3 @@ class SetFu (redis_obj):
     def __ior__(self, other):
         self.update(other)
         return self
-

--- a/redis_wrap/redis_systems.py
+++ b/redis_wrap/redis_systems.py
@@ -1,13 +1,14 @@
 import redis
 
-
 #--- System related ----------------------------------------------
 SYSTEMS = {
     'default': redis.Redis(host='localhost', port=6379)
 }
 
+
 def setup_system(name, host, port, **kw):
     SYSTEMS[name] = redis.Redis(host=host, port=port, **kw)
+
 
 def get_redis(system='default'):
     return SYSTEMS[system]
@@ -21,4 +22,3 @@ class redis_obj:
 
     def clear(self):
         self.conn.delete(self.name)
-

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 from setuptools import setup
 
 setup(name='redis_wrap',
-      version = '1.4.3',
+      version = '1.4.4',
       author="amix",
       author_email="amix@amix.dk",
       url="http://www.amix.dk/",

--- a/test/test.py
+++ b/test/test.py
@@ -1,5 +1,13 @@
+#!/usr/bin/env python2
+# encoding: utf-8
+
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+
 import sys
-from redis_wrap import get_redis, get_list, get_hash, get_set, get_bitset
+
+from redis_wrap import get_bitset, get_hash, get_list, get_redis, get_set
+
 
 def raises(f, excpt):
     try:
@@ -15,7 +23,8 @@ def setup_module(module=None):
     get_redis().delete('villains')
     get_redis().delete('fishes')
 
-    print sys._getframe(0).f_code.co_name, 'ok.'
+    print(sys._getframe(0).f_code.co_name, 'ok.')
+
 
 def test_list():
     bears = get_list('bears')
@@ -23,6 +32,8 @@ def test_list():
 
     bears.append('grizzly')
     assert len(bears) == 1
+    assert bears[0] == 'grizzly'
+    assert bears[-1] == 'grizzly'
 
     for bear in bears:
         assert bear == 'grizzly'
@@ -42,13 +53,19 @@ def test_list():
         pass
 
     bears.extend(['polar bear', 'gummy bear'])
-    assert bears[1:2] == ['white bear', 'nice bear']
-    assert bears[2:4] == ['nice bear', 'polar bear', 'gummy bear']
+    assert list(bears) == ['grizzly', 'white bear', 'nice bear', 'polar bear', 'gummy bear']
+
+    assert bears[1:2] == ['white bear']
+    assert bears[2:4] == ['nice bear', 'polar bear']
+    assert bears[:2] == ['grizzly', 'white bear']
+    assert bears[-2:] == ['polar bear', 'gummy bear']
+    assert bears[10:20] == []
 
     bears.remove('grizzly')
     assert 'grizzly' not in bears
 
-    print sys._getframe(0).f_code.co_name, 'ok.'
+    print(sys._getframe(0).f_code.co_name, 'ok.')
+
 
 def test_list_trim():
     deers = get_list('deers')
@@ -65,7 +82,8 @@ def test_list_trim():
     assert deers[0] == 'rudolf_0'
     assert deers[1] == 'rudolf_1'
 
-    print sys._getframe(0).f_code.co_name, 'ok.'
+    print(sys._getframe(0).f_code.co_name, 'ok.')
+
 
 def test_hash():
     villains = get_hash('villains')
@@ -112,7 +130,8 @@ def test_hash():
         ('lizard','Curt Connors'),
         ('rhino', 'Aleksei Sytsevich')])
 
-    print sys._getframe(0).f_code.co_name, 'ok.'
+    print(sys._getframe(0).f_code.co_name, 'ok.')
+
 
 def test_set():
     fishes = get_set('fishes')
@@ -188,7 +207,9 @@ def test_set():
     fishes.update(('nemo','marlin', 'dory', 'gill', 'bloat'))
     fishes ^= other_fishes
     assert set(fishes) == set(['nemo','marlin', 'dory', 'flo'])
-    print sys._getframe(0).f_code.co_name, 'ok.'
+
+    print(sys._getframe(0).f_code.co_name, 'ok.')
+
 
 def test_bitset():
     users = get_bitset('users')
@@ -220,7 +241,8 @@ def test_bitset():
     users.clear()
     assert len(users) == 0
 
-    print sys._getframe(0).f_code.co_name, 'ok.'
+    print(sys._getframe(0).f_code.co_name, 'ok.')
+
 
 if __name__ == '__main__':
     setup_module()


### PR DESCRIPTION
Several changes here:
* `.gitignore` is added (it should be in the repository)
* List slicing is corrected. I also added some extra test cases for the lists.
* `from __future__` I imported 4 things. It will make the transition to Python 3 easier in the future.
* `test.py` now runs with Python 3 but it fails due to different string handling. This is something TODO in the future.
